### PR TITLE
add missing runtime dependency 'zip'

### DIFF
--- a/lambda_wrap.gemspec
+++ b/lambda_wrap.gemspec
@@ -11,4 +11,5 @@ Gem::Specification.new do |s|
   s.license       = 'Apache-2.0'
   s.require_paths = ['lib']
   s.add_runtime_dependency('aws-sdk', '~> 2')
+  s.add_runtime_dependency('zip', '~> 2')
 end


### PR DESCRIPTION
I tested this locally and it now installs a version of zip. That gets rid of the error ('zip not found')