### PR TITLE
Changes the Region variable to be the one specified in the AWS docs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lambda_wrap (0.0.0)
+    lambda_wrap (0.16.0)
       aws-sdk (~> 2)
       rubyzip (~> 1.2)
 
@@ -9,15 +9,15 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.3.0)
-    aws-sdk (2.3.13)
-      aws-sdk-resources (= 2.3.13)
-    aws-sdk-core (2.3.13)
+    aws-sdk (2.3.20)
+      aws-sdk-resources (= 2.3.20)
+    aws-sdk-core (2.3.20)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.3.13)
-      aws-sdk-core (= 2.3.13)
+    aws-sdk-resources (2.3.20)
+      aws-sdk-core (= 2.3.20)
     jmespath (1.2.4)
       json_pure (>= 1.8.1)
-    json_pure (1.8.3)
+    json_pure (2.0.1)
     parser (2.3.1.2)
       ast (~> 2.2)
     powerpack (0.1.1)

--- a/lib/lambda_wrap/api_gateway_manager.rb
+++ b/lib/lambda_wrap/api_gateway_manager.rb
@@ -57,7 +57,7 @@ module LambdaWrap
     # [stage_variables] A Hash of stage variables to be deployed with the stage. Adds an 'environment' by default.
     # [region] The region to deploy the API. Defaults to what is set as an environment variable.
     def setup_apigateway(api_name, env, swagger_file, api_description = 'Deployed with LambdaWrap',
-                         stage_variables = {}, region = ENV['AWS_REGION'])
+                         stage_variables = {}, region = ENV['AWS_DEFAULT_REGION'])
       # ensure API is created
       api_id = get_existing_rest_api(api_name)
       api_id = setup_apigateway_create_rest_api(api_name, api_description) unless api_id


### PR DESCRIPTION
 See: http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html
They use AWS_DEFAULT_REGION .
I was getting jenkins errors because I had set the AWS_DEFAULT_REGION when LambdaWrap was expecting AWS_REGION.